### PR TITLE
Fix setPinInterrupt & new features

### DIFF
--- a/SC16IS752.cpp
+++ b/SC16IS752.cpp
@@ -25,6 +25,16 @@
 #include <SPI.h>
 #include <Wire.h>
 
+#ifdef __AVR__
+ # define WIRE Wire
+#elif ESP8266 // ESP8266
+ # define WIRE Wire
+#elif ESP32 // ESP8266
+ # define WIRE Wire
+#else // Arduino Due
+ # define WIRE Wire1
+#endif // ifdef __AVR__
+
 
 SC16IS752::SC16IS752(uint8_t prtcl, uint8_t addr_sspin) : initialized(false)
 {
@@ -114,11 +124,11 @@ uint8_t SC16IS752::ReadRegister(uint8_t channel, uint8_t reg_addr)
   uint8_t result = 0;
 
   if (protocol == SC16IS750_PROTOCOL_I2C) { // register read operation via I2C
-    Wire.beginTransmission(device_address_sspin);
-    Wire.write((reg_addr << 3 | channel << 1));
-    Wire.endTransmission(0);
-    Wire.requestFrom(device_address_sspin, (uint8_t)1);
-    result = Wire.read();
+    WIRE.beginTransmission(device_address_sspin);
+    WIRE.write((reg_addr << 3 | channel << 1));
+    WIRE.endTransmission(0);
+    WIRE.requestFrom(device_address_sspin, (uint8_t)1);
+    result = WIRE.read();
   } else if (protocol == SC16IS750_PROTOCOL_SPI) { // register read operation via SPI
     ::digitalWrite(device_address_sspin, LOW);
     delayMicroseconds(10);
@@ -151,10 +161,10 @@ void SC16IS752::WriteRegister(uint8_t channel, uint8_t reg_addr, uint8_t val)
 #endif // ifdef  SC16IS750_DEBUG_PRINT
 
   if (protocol == SC16IS750_PROTOCOL_I2C) { // register read operation via I2C
-    Wire.beginTransmission(device_address_sspin);
-    Wire.write((reg_addr << 3 | channel << 1));
-    Wire.write(val);
-    Wire.endTransmission(1);
+    WIRE.beginTransmission(device_address_sspin);
+    WIRE.write((reg_addr << 3 | channel << 1));
+    WIRE.write(val);
+    WIRE.endTransmission(1);
   } else {
     ::digitalWrite(device_address_sspin, LOW);
     delayMicroseconds(10);
@@ -168,7 +178,7 @@ void SC16IS752::WriteRegister(uint8_t channel, uint8_t reg_addr, uint8_t val)
 void SC16IS752::Initialize()
 {
   if (protocol == SC16IS750_PROTOCOL_I2C) {
-    Wire.begin();
+    WIRE.begin();
   } else {
     ::pinMode(device_address_sspin, OUTPUT);
     ::digitalWrite(device_address_sspin, HIGH);
@@ -602,34 +612,32 @@ uint8_t SC16IS752::ping()
    }
  */
  
-   size_t SC16IS752::readBytes(uint8_t channel, uint8_t *buffer, size_t length)
-   {
-        size_t count=0;
-        int16_t tmp;
+size_t SC16IS752::readBytes(uint8_t channel, uint8_t *buffer, size_t length)
+{
+  size_t count=0;
+  int16_t tmp;
 
-        while (count < length) {
-                tmp = ReadByte(channel);
-                if (tmp < 0) {
-                        break;
-                }
-				*buffer++ = tmp;
-                count++;
-        }
-
-        return count;
-   }
+  while (count < length) {
+	tmp = ReadByte(channel);
+	if (tmp < 0) {
+			break;
+	}
+	*buffer++ = tmp;
+	count++;
+  }
+  return count;
+}
    
-   String SC16IS752::readStringUntil(uint8_t channel, char terminator)
-   {
-		String ret;
-        int c = ReadByte(channel);
-		while(c >= 0 && c != terminator) {
-			ret += (char) c;
-			c = ReadByte(channel);
-		}
-
-        return ret;
-   }
+String SC16IS752::readStringUntil(uint8_t channel, char terminator)
+{
+  String ret;
+  int c = ReadByte(channel);
+  while(c >= 0 && c != terminator) {
+	ret += (char) c;
+	c = ReadByte(channel);
+  }
+  return ret;
+}
    
 /*
    int16_t SC16IS752::readwithtimeout()

--- a/SC16IS752.h
+++ b/SC16IS752.h
@@ -133,12 +133,14 @@ public:
   uint8_t ping();
 
   //	void setTimeout(uint32_t);
-  //	size_t readBytes(char *buffer, size_t length);
+  size_t readBytes(uint8_t channel, uint8_t *buffer, size_t length);
+  String readStringUntil(uint8_t channel, char terminator);
   int     peek(uint8_t channel);
   void    flush(uint8_t channel);
   uint8_t GPIOGetPortState(void);
   uint8_t InterruptPendingTest(uint8_t channel);
-  void    SetPinInterrupt(uint8_t io_int_ena);
+  void    SetPinInterrupt(uint8_t pin_number, bool int_ena);
+  uint8_t GetPinInterrupt(uint8_t pin_number);
   void    InterruptControl(uint8_t channel,
                            uint8_t int_ena);
   void    ModemPin(uint8_t gpio); // gpio == 0, gpio[7:4] are modem pins, gpio == 1 gpio[7:4] are gpios

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "SC16IS752",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "keywords": [
       "serial", "io", "sc16is752", "i2c", "uart"
     ],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SC16IS752
-version=1.0.1
+version=1.0.2
 author=Gijs Noorlander
 maintainer=Gijs Noorlander <gijs.noorlander@gmail.com>
 sentence=NXP SC16IS752 I2C UART bridge for ESP8266 and ESP32.


### PR DESCRIPTION
Changes that I have made:
* Changed all "WIRE" to "Wire" and removed creating WIRE object at the beginning of .cpp. Thanks to this, it is possible to use I2C on custom pins on ESP32. If it destroys any other functionality, it is worth to consider passing Wire object in constructor / begin method.
* Changed ```SetPinInterrupt();``` function so it is possible to enable or disable interrupt on specific pin
* Added ```GetPinInterrupt()``` function
* Added ```readBytes()``` function
* Added ```readStringUntil()``` function